### PR TITLE
Improve board sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# life
-See if I can start a project from scratch using chatgpt codex
+# Life
+
+A minimal implementation of John Horton Conway's [Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) in Python.
+The board automatically sizes itself to your terminal (fallback 20x10).
+
+## Running locally
+
+1. Ensure you have Python 3 installed.
+2. From this directory, run:
+   ```bash
+   python3 life.py
+   ```
+3. The simulation will display generations in your terminal. Press `Ctrl+C` to stop.
+
+By default the board uses your terminal's current size. If detection fails, you can supply dimensions using:
+
+```bash
+stty size | python3 life.py
+```

--- a/life.py
+++ b/life.py
@@ -1,0 +1,86 @@
+import random
+import time
+import os
+import sys
+import shutil
+
+# Simple implementation of Conway's Game of Life
+
+DEFAULT_WIDTH = 20
+DEFAULT_HEIGHT = 10
+ALIVE = 'O'
+DEAD = ' '
+
+def random_grid(width, height):
+    return [[random.choice([True, False]) for _ in range(width)] for _ in range(height)]
+
+def print_grid(grid):
+    os.system('cls' if os.name == 'nt' else 'clear')
+    for row in grid:
+        print(''.join(ALIVE if cell else DEAD for cell in row))
+
+def count_neighbors(grid, x, y):
+    height = len(grid)
+    width = len(grid[0])
+    count = 0
+    for dy in (-1, 0, 1):
+        for dx in (-1, 0, 1):
+            if dx == 0 and dy == 0:
+                continue
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < width and 0 <= ny < height:
+                if grid[ny][nx]:
+                    count += 1
+    return count
+
+def step(grid):
+    height = len(grid)
+    width = len(grid[0])
+    new_grid = [[False] * width for _ in range(height)]
+    for y in range(height):
+        for x in range(width):
+            neighbors = count_neighbors(grid, x, y)
+            if grid[y][x]:
+                new_grid[y][x] = neighbors in (2, 3)
+            else:
+                new_grid[y][x] = neighbors == 3
+    return new_grid
+
+def get_board_size():
+    """Determine board size from terminal or piped input."""
+    width = height = None
+    try:
+        size = shutil.get_terminal_size()
+        width, height = size.columns, size.lines
+    except OSError:
+        pass
+
+    if (width is None or height is None) and not sys.stdin.isatty():
+        data = sys.stdin.read().strip().split()
+        if len(data) >= 2 and data[0].isdigit() and data[1].isdigit():
+            height = int(data[0])
+            width = int(data[1])
+
+    if width is None or height is None:
+        width = DEFAULT_WIDTH
+        height = DEFAULT_HEIGHT
+
+    return width, height
+
+
+def main():
+    width, height = get_board_size()
+    grid = random_grid(width, height)
+    generation = 0
+    try:
+        while True:
+            print_grid(grid)
+            print(f"Generation: {generation}")
+            generation += 1
+            grid = step(grid)
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        print("\nSimulation stopped.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- detect terminal dimensions for board size with fallback to defaults
- allow size from piped `stty size` output
- document automatic sizing and piping usage

## Testing
- `python3 -m py_compile life.py`