### PR TITLE
Enable auto board sizing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
-# life
-See if I can start a project from scratch using chatgpt codex
+# Life
+
+A minimal implementation of John Horton Conway's [Game of Life](https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life) in Python.
+
+## Running locally
+
+1. Ensure you have Python 3 installed.
+2. From this directory, run:
+   ```bash
+   python3 life.py
+   ```
+3. The simulation will display generations in your terminal. Press `Ctrl+C` to stop.
+
+The board size defaults to your terminal dimensions. You can also pipe the output of
+`stty size` to the program to specify custom dimensions:
+
+```bash
+stty size | python3 life.py
+```

--- a/life.py
+++ b/life.py
@@ -1,0 +1,78 @@
+import random
+import time
+import os
+import sys
+import shutil
+
+# Simple implementation of Conway's Game of Life
+
+DEFAULT_WIDTH = 20
+DEFAULT_HEIGHT = 10
+ALIVE = 'O'
+DEAD = ' '
+
+
+def get_board_size():
+    """Return (width, height) based on terminal or piped input."""
+    if not sys.stdin.isatty():
+        data = sys.stdin.read().strip()
+        if data:
+            try:
+                rows, cols = map(int, data.split())
+                return cols, rows
+            except ValueError:
+                pass
+    size = shutil.get_terminal_size((DEFAULT_WIDTH, DEFAULT_HEIGHT))
+    return size.columns, size.lines
+
+def random_grid(width, height):
+    return [[random.choice([True, False]) for _ in range(width)] for _ in range(height)]
+
+def print_grid(grid):
+    os.system('cls' if os.name == 'nt' else 'clear')
+    for row in grid:
+        print(''.join(ALIVE if cell else DEAD for cell in row))
+
+def count_neighbors(grid, x, y):
+    height = len(grid)
+    width = len(grid[0])
+    count = 0
+    for dy in (-1, 0, 1):
+        for dx in (-1, 0, 1):
+            if dx == 0 and dy == 0:
+                continue
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < width and 0 <= ny < height:
+                if grid[ny][nx]:
+                    count += 1
+    return count
+
+def step(grid):
+    height = len(grid)
+    width = len(grid[0])
+    new_grid = [[False] * width for _ in range(height)]
+    for y in range(height):
+        for x in range(width):
+            neighbors = count_neighbors(grid, x, y)
+            if grid[y][x]:
+                new_grid[y][x] = neighbors in (2, 3)
+            else:
+                new_grid[y][x] = neighbors == 3
+    return new_grid
+
+def main():
+    width, height = get_board_size()
+    grid = random_grid(width, height)
+    generation = 0
+    try:
+        while True:
+            print_grid(grid)
+            print(f"Generation: {generation}")
+            generation += 1
+            grid = step(grid)
+            time.sleep(0.5)
+    except KeyboardInterrupt:
+        print("\nSimulation stopped.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `get_board_size` to size the grid from terminal dimensions or piped input
- use `get_board_size` in `main`
- document the sizing behavior and how to pass in custom dimensions via `stty size`

## Testing
- `python3 -m py_compile life.py`
