### PR TITLE
Auto detect board size

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,12 @@ A minimal implementation of John Horton Conway's [Game of Life](https://en.wikip
    ```
 3. The simulation will display generations in your terminal. Press `Ctrl+C` to stop.
 
-You can edit `WIDTH` and `HEIGHT` at the top of `life.py` to change the board size.
+The board now automatically scales to your terminal size. You can also pipe the
+output of `stty size` to specify a custom size:
+
+```bash
+stty size | python3 life.py
+```
+
+You can still edit `WIDTH` and `HEIGHT` at the top of `life.py` if you want to
+specify fixed dimensions regardless of your terminal size.

--- a/life.py
+++ b/life.py
@@ -1,6 +1,8 @@
 import random
 import time
 import os
+import sys
+import shutil
 
 # Simple implementation of Conway's Game of Life
 
@@ -8,6 +10,22 @@ WIDTH = 20
 HEIGHT = 10
 ALIVE = 'O'
 DEAD = ' '
+
+
+def get_board_size(default_width, default_height):
+    """Determine board size using stdin or terminal size."""
+    width, height = default_width, default_height
+    if not sys.stdin.isatty():
+        data = sys.stdin.read().strip().split()
+        if len(data) >= 2 and all(part.isdigit() for part in data[:2]):
+            height, width = int(data[0]), int(data[1])
+            return width, height
+    try:
+        size = shutil.get_terminal_size()
+        width, height = size.columns, size.lines - 1
+    except OSError:
+        pass
+    return width, height
 
 def random_grid(width, height):
     return [[random.choice([True, False]) for _ in range(width)] for _ in range(height)]
@@ -45,6 +63,8 @@ def step(grid):
     return new_grid
 
 def main():
+    global WIDTH, HEIGHT
+    WIDTH, HEIGHT = get_board_size(WIDTH, HEIGHT)
     grid = random_grid(WIDTH, HEIGHT)
     generation = 0
     try:


### PR DESCRIPTION
## Summary
- auto-determine board dimensions from stdin or terminal size
- document automatic sizing in README

## Testing
- `python3 -m py_compile life.py`
