### PR TITLE
Add unbounded board with panning and zoom

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ python3 life.py --gui
 
 You can still pipe `stty size` to specify a window size or edit `WIDTH` and `HEIGHT` in `life.py`.
 
+### New features
+
+The board is now unbounded. When running in GUI mode you can use the arrow keys to pan around the infinite board and `+` or `-` to zoom in and out.
+
 The board now automatically scales to your terminal size. You can also pipe the
 output of `stty size` to specify a custom size:
 

--- a/life.py
+++ b/life.py
@@ -10,14 +10,21 @@ try:
 except ImportError:
     tk = None
 
-# Simple implementation of Conway's Game of Life
+# Simple implementation of Conway's Game of Life using an unbounded board
 
+# Initial area of random live cells
 WIDTH = 20
 HEIGHT = 10
+
 ALIVE = 'O'
 DEAD = ' '
 
+# Visualisation defaults
 CELL_SIZE = 10  # pixel size of a cell when using GUI mode
+
+# panning/zooming
+OFFSET_X = 0
+OFFSET_Y = 0
 
 
 def get_board_size(default_width, default_height):
@@ -35,81 +42,122 @@ def get_board_size(default_width, default_height):
         pass
     return width, height
 
-def random_grid(width, height):
-    return [[random.choice([True, False]) for _ in range(width)] for _ in range(height)]
 
-def print_grid(grid):
-    os.system('cls' if os.name == 'nt' else 'clear')
-    for row in grid:
-        print(''.join(ALIVE if cell else DEAD for cell in row))
+# ---------------------------------------------------------------------------
+# Data helpers operating on a set of live cell coordinates
+# ---------------------------------------------------------------------------
 
-
-def draw_grid_tk(canvas, grid):
-    """Render the grid on a tkinter canvas."""
-    canvas.delete("all")
-    height = len(grid)
-    width = len(grid[0])
+def random_cells(width, height):
+    cells = set()
     for y in range(height):
         for x in range(width):
-            if grid[y][x]:
-                canvas.create_rectangle(
-                    x * CELL_SIZE,
-                    y * CELL_SIZE,
-                    (x + 1) * CELL_SIZE,
-                    (y + 1) * CELL_SIZE,
-                    fill="black",
-                    outline=""
-                )
+            if random.choice([True, False]):
+                cells.add((x, y))
+    return cells
+
+
+def bounding_box(cells):
+    if not cells:
+        return 0, 0, 0, 0
+    xs = [c[0] for c in cells]
+    ys = [c[1] for c in cells]
+    return min(xs), min(ys), max(xs), max(ys)
+
+
+def print_cells(cells):
+    os.system('cls' if os.name == 'nt' else 'clear')
+    min_x, min_y, max_x, max_y = bounding_box(cells)
+    for y in range(min_y, max_y + 1):
+        row = ''
+        for x in range(min_x, max_x + 1):
+            row += ALIVE if (x, y) in cells else DEAD
+        print(row)
+
+
+def step(cells):
+    """Compute the next generation for an unbounded board."""
+    neighbor_counts = {}
+    for (x, y) in cells:
+        for dy in (-1, 0, 1):
+            for dx in (-1, 0, 1):
+                if dx == 0 and dy == 0:
+                    continue
+                key = (x + dx, y + dy)
+                neighbor_counts[key] = neighbor_counts.get(key, 0) + 1
+    new_cells = set()
+    for cell, count in neighbor_counts.items():
+        if count == 3 or (count == 2 and cell in cells):
+            new_cells.add(cell)
+    return new_cells
+
+
+# ---------------------------------------------------------------------------
+# Tkinter visualisation with panning and zooming
+# ---------------------------------------------------------------------------
+
+def draw_cells_tk(canvas, cells, offset_x, offset_y, cell_size):
+    canvas.delete("all")
+    for x, y in cells:
+        sx = (x - offset_x) * cell_size
+        sy = (y - offset_y) * cell_size
+        canvas.create_rectangle(
+            sx,
+            sy,
+            sx + cell_size,
+            sy + cell_size,
+            fill="black",
+            outline="",
+        )
     canvas.update()
 
-def count_neighbors(grid, x, y):
-    height = len(grid)
-    width = len(grid[0])
-    count = 0
-    for dy in (-1, 0, 1):
-        for dx in (-1, 0, 1):
-            if dx == 0 and dy == 0:
-                continue
-            nx, ny = x + dx, y + dy
-            if 0 <= nx < width and 0 <= ny < height:
-                if grid[ny][nx]:
-                    count += 1
-    return count
 
-def step(grid):
-    height = len(grid)
-    width = len(grid[0])
-    new_grid = [[False] * width for _ in range(height)]
-    for y in range(height):
-        for x in range(width):
-            neighbors = count_neighbors(grid, x, y)
-            if grid[y][x]:
-                new_grid[y][x] = neighbors in (2, 3)
-            else:
-                new_grid[y][x] = neighbors == 3
-    return new_grid
-
-
-def run_gui(grid):
+def run_gui(cells):
     """Run the simulation using a tkinter window."""
     if tk is None:
         raise RuntimeError("tkinter is not available")
 
+    global OFFSET_X, OFFSET_Y, CELL_SIZE
+
     root = tk.Tk()
-    canvas = tk.Canvas(root, width=WIDTH * CELL_SIZE, height=HEIGHT * CELL_SIZE, bg="white")
-    canvas.pack()
+    canvas = tk.Canvas(root, width=800, height=600, bg="white")
+    canvas.pack(fill="both", expand=True)
+    root.focus_set()
+
     generation = 0
 
     def update():
-        nonlocal grid, generation
-        draw_grid_tk(canvas, grid)
+        nonlocal cells, generation
+        draw_cells_tk(canvas, cells, OFFSET_X, OFFSET_Y, CELL_SIZE)
         root.title(f"Game of Life - Generation {generation}")
         generation += 1
-        grid = step(grid)
+        cells = step(cells)
         root.after(500, update)
+
+    def on_key(event):
+        global CELL_SIZE, OFFSET_X, OFFSET_Y
+        if event.keysym == 'Up':
+            OFFSET_Y -= 5
+        elif event.keysym == 'Down':
+            OFFSET_Y += 5
+        elif event.keysym == 'Left':
+            OFFSET_X -= 5
+        elif event.keysym == 'Right':
+            OFFSET_X += 5
+        elif event.keysym in ('plus', 'equal'):
+            CELL_SIZE = min(int(CELL_SIZE * 1.2), 50)
+        elif event.keysym in ('minus', 'underscore'):
+            CELL_SIZE = max(int(CELL_SIZE / 1.2), 2)
+        draw_cells_tk(canvas, cells, OFFSET_X, OFFSET_Y, CELL_SIZE)
+
+    root.bind('<Key>', on_key)
 
     update()
     root.mainloop()
+
+
+# ---------------------------------------------------------------------------
+# Main loop for terminal mode
+# ---------------------------------------------------------------------------
 
 def main():
     parser = argparse.ArgumentParser(description="Conway's Game of Life")
@@ -118,22 +166,24 @@ def main():
 
     global WIDTH, HEIGHT
     WIDTH, HEIGHT = get_board_size(WIDTH, HEIGHT)
-    grid = random_grid(WIDTH, HEIGHT)
+    cells = random_cells(WIDTH, HEIGHT)
 
     if args.gui:
-        run_gui(grid)
+        run_gui(cells)
         return
 
     generation = 0
     try:
         while True:
-            print_grid(grid)
+            print_cells(cells)
             print(f"Generation: {generation}")
             generation += 1
-            grid = step(grid)
+            cells = step(cells)
             time.sleep(0.5)
     except KeyboardInterrupt:
         print("\nSimulation stopped.")
+
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- support an unbounded board backed by a set of live cell coordinates
- add panning with arrow keys and zoom in/out with `+`/`-` in GUI mode
- document the new features

## Testing
- `python3 life.py --help`
- `python3 life.py --gui` *(fails: can't open display)*